### PR TITLE
add psu input voltage and current

### DIFF
--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -244,3 +244,22 @@ class PsuBase(device_base.DeviceBase):
         """
         cls._psu_master_led_color = color
         return True
+
+    def get_input_voltage(self):
+        """
+        Retrieves current PSU voltage input
+
+        Returns:
+            A float number, the input voltage in volts,
+            e.g. 12.1
+        """
+        raise NotImplementedError
+
+    def get_input_current(self):
+        """
+        Retrieves the input current draw of the power supply
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Signed-off-by: orfar1994 <orfar1994@gmail.com>

Add PSU input voltage and input current.

#### Description
psud would collect input voltage and input current of the PSU. 

#### Motivation and Context
more information about the PSU. 

#### How Has This Been Tested?
unitests, on switch.

#### Additional Information (Optional)

